### PR TITLE
Fix integration test discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       - name: Cargo fmt
         run: cargo fmt --all -- --check
       - name: Cargo clippy

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,0 +1,7 @@
+mod dkim_signing;
+mod import_export;
+mod inbox_flow;
+mod main_smoke;
+mod outbox_retry;
+mod retention;
+mod routing;


### PR DESCRIPTION
## Summary
- add a module shim in `tests/integration` so Cargo picks up the integration suites

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d78fdac75c83209afbf8337a30e207