### PR TITLE
Resolve clippy regressions and simplify linted code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       - name: Cargo fmt
         run: cargo fmt --all -- --check
       - name: Cargo clippy

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -158,8 +158,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let layout = MailLayout::new(dir.path());
         layout.ensure().unwrap();
-        let mut env = EnvConfig::default();
-        env.retry_backoff = vec!["1s".into()];
+        let env = EnvConfig {
+            retry_backoff: vec!["1s".into()],
+            ..EnvConfig::default()
+        };
         let logger = Logger::new(layout.root(), LogLevel::Off).unwrap();
         let transport: Arc<dyn MailTransport> = Arc::new(SucceedingTransport);
         let pipeline = Arc::new(OutboxPipeline::with_transport(

--- a/src/daemon/watch.rs
+++ b/src/daemon/watch.rs
@@ -98,7 +98,7 @@ fn watch_loop(
                 let _ = sender.send(res);
             }
         },
-        config.clone(),
+        config,
     ) {
         Ok(watcher) => watchers.push(Box::new(watcher)),
         Err(err) => handler(WatchEvent {
@@ -159,23 +159,19 @@ fn dispatch_event(list: WatchList, handler: &Handler, event: notify::Event) {
 
 fn classify_event(kind: &EventKind) -> Option<WatchEventKind> {
     match kind {
-        EventKind::Create(create) => match create {
-            CreateKind::Any | CreateKind::File | CreateKind::Folder => {
-                Some(WatchEventKind::Created)
-            }
-            _ => None,
-        },
+        EventKind::Create(CreateKind::Any | CreateKind::File | CreateKind::Folder) => {
+            Some(WatchEventKind::Created)
+        }
+        EventKind::Create(_) => None,
         EventKind::Modify(ModifyKind::Any)
         | EventKind::Modify(ModifyKind::Data(DataChange::Content))
         | EventKind::Modify(ModifyKind::Data(DataChange::Any))
         | EventKind::Modify(ModifyKind::Metadata(_))
         | EventKind::Modify(ModifyKind::Name(_)) => Some(WatchEventKind::Modified),
-        EventKind::Remove(remove) => match remove {
-            RemoveKind::Any | RemoveKind::File | RemoveKind::Folder => {
-                Some(WatchEventKind::Removed)
-            }
-            _ => None,
-        },
+        EventKind::Remove(RemoveKind::Any | RemoveKind::File | RemoveKind::Folder) => {
+            Some(WatchEventKind::Removed)
+        }
+        EventKind::Remove(_) => None,
         _ => None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,9 @@
+#[cfg(not(test))]
+use clap::Parser;
+#[cfg(test)]
+use owl::cli::Commands;
 use owl::{
-    cli::{Commands, OwlCli, run},
+    cli::{OwlCli, run},
     envcfg::EnvConfig,
 };
 use std::path::Path;
@@ -33,8 +37,8 @@ fn main() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
     use serial_test::serial;
+    use tempfile::tempdir;
 
     fn with_fake_ops_env<T>(f: impl FnOnce() -> T) -> T {
         let dir = tempdir().unwrap();

--- a/src/model/address.rs
+++ b/src/model/address.rs
@@ -17,10 +17,8 @@ impl Address {
             bail!("missing @ in address: {input}");
         };
         let mut local = local_raw.trim().to_ascii_lowercase();
-        if !keep_plus_tags {
-            if let Some((base, _tag)) = local.split_once('+') {
-                local = base.to_string();
-            }
+        if !keep_plus_tags && let Some((base, _tag)) = local.split_once('+') {
+            local = base.to_string();
         }
         let domain_lower = domain_raw.trim().to_ascii_lowercase();
         let domain_ascii =

--- a/src/model/rules.rs
+++ b/src/model/rules.rs
@@ -2,6 +2,7 @@ use crate::model::address::Address;
 use anyhow::{Result, bail};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Rule {
@@ -53,7 +54,7 @@ pub struct RuleSet {
 }
 
 impl RuleSet {
-    pub fn from_str(data: &str) -> Result<Self> {
+    pub fn parse(data: &str) -> Result<Self> {
         let mut rules = Vec::new();
         for line in data.lines() {
             let trimmed = line.trim();
@@ -79,6 +80,14 @@ impl RuleSet {
     }
 }
 
+impl FromStr for RuleSet {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,7 +108,7 @@ mod tests {
     #[test]
     fn ruleset_evaluates_in_order() {
         let data = "@example.org\ncarol@example.org";
-        let set = RuleSet::from_str(data).unwrap();
+        let set: RuleSet = data.parse().unwrap();
         let addr = Address::parse("carol@example.org", false).unwrap();
         let matched = set.evaluate(&addr).unwrap();
         assert!(matches!(matched, Rule::DomainSuffix(_)));

--- a/src/ops/install.rs
+++ b/src/ops/install.rs
@@ -169,13 +169,12 @@ fn run_certbot(layout: &MailLayout, env: &EnvConfig, logger: &Logger) -> Result<
         .stderr_capture()
         .stdout_capture()
         .run()
-        .map_err(|err| {
+        .inspect_err(|err| {
             let _ = logger.log(
                 LogLevel::Minimal,
                 "install.ops.certbot.error",
                 Some(&err.to_string()),
             );
-            err
         })?;
     logger.log(
         LogLevel::Minimal,
@@ -190,37 +189,34 @@ fn enable_rspamd(logger: &Logger) -> Result<()> {
         .stderr_capture()
         .stdout_capture()
         .run()
-        .map_err(|err| {
+        .inspect_err(|err| {
             let _ = logger.log(
                 LogLevel::Minimal,
                 "install.ops.rspamd.error",
                 Some(&err.to_string()),
             );
-            err
         })?;
     cmd("systemctl", ["enable", "rspamd"])
         .stderr_capture()
         .stdout_capture()
         .run()
-        .map_err(|err| {
+        .inspect_err(|err| {
             let _ = logger.log(
                 LogLevel::Minimal,
                 "install.ops.rspamd.enable_error",
                 Some(&err.to_string()),
             );
-            err
         })?;
     cmd("systemctl", ["restart", "rspamd"])
         .stderr_capture()
         .stdout_capture()
         .run()
-        .map_err(|err| {
+        .inspect_err(|err| {
             let _ = logger.log(
                 LogLevel::Minimal,
                 "install.ops.rspamd.restart_error",
                 Some(&err.to_string()),
             );
-            err
         })?;
     logger.log(LogLevel::Minimal, "install.ops.rspamd", None)?;
     Ok(())
@@ -231,13 +227,12 @@ fn reload_postfix(logger: &Logger) -> Result<()> {
         .stderr_capture()
         .stdout_capture()
         .run()
-        .map_err(|err| {
+        .inspect_err(|err| {
             let _ = logger.log(
                 LogLevel::Minimal,
                 "install.ops.postfix.error",
                 Some(&err.to_string()),
             );
-            err
         })?;
     logger.log(LogLevel::Minimal, "install.ops.postfix", None)?;
     Ok(())
@@ -248,13 +243,12 @@ fn sync_chrony(logger: &Logger) -> Result<()> {
         .stderr_capture()
         .stdout_capture()
         .run()
-        .map_err(|err| {
+        .inspect_err(|err| {
             let _ = logger.log(
                 LogLevel::Minimal,
                 "install.ops.chrony.error",
                 Some(&err.to_string()),
             );
-            err
         })?;
     logger.log(LogLevel::Minimal, "install.ops.chrony", None)?;
     Ok(())

--- a/src/pipeline/inbound.rs
+++ b/src/pipeline/inbound.rs
@@ -43,7 +43,7 @@ mod tests {
     fn banned_wins() {
         let sender = Address::parse("foo@bar.com", false).unwrap();
         let mut rules = LoadedRules::default();
-        rules.banned.rules = RuleSet::from_str("@bar.com").unwrap();
+        rules.banned.rules = RuleSet::parse("@bar.com").unwrap();
         let route = determine_route(&sender, &rules, &EnvConfig::default()).unwrap();
         assert_eq!(route, Route::Banned);
     }
@@ -52,7 +52,7 @@ mod tests {
     fn list_status_overrides() {
         let sender = Address::parse("foo@example.com", false).unwrap();
         let mut rules = LoadedRules::default();
-        rules.accepted.rules = RuleSet::from_str("@example.com").unwrap();
+        rules.accepted.rules = RuleSet::parse("@example.com").unwrap();
         rules.accepted.settings.list_status = "banned".into();
         let route = determine_route(&sender, &rules, &EnvConfig::default()).unwrap();
         assert_eq!(route, Route::Banned);
@@ -62,7 +62,7 @@ mod tests {
     fn spam_branch_maps_status() {
         let sender = Address::parse("foo@spam.test", false).unwrap();
         let mut rules = LoadedRules::default();
-        rules.spam.rules = RuleSet::from_str("@spam.test").unwrap();
+        rules.spam.rules = RuleSet::parse("@spam.test").unwrap();
         let spam_route = determine_route(&sender, &rules, &EnvConfig::default()).unwrap();
         assert_eq!(spam_route, Route::Spam);
         rules.spam.settings.list_status = "accepted".into();
@@ -82,7 +82,7 @@ mod tests {
     fn invalid_status_errors() {
         let sender = Address::parse("foo@example.com", false).unwrap();
         let mut rules = LoadedRules::default();
-        rules.accepted.rules = RuleSet::from_str("@example.com").unwrap();
+        rules.accepted.rules = RuleSet::parse("@example.com").unwrap();
         rules.accepted.settings.list_status = "unknown".into();
         let err = determine_route(&sender, &rules, &EnvConfig::default()).unwrap_err();
         assert!(err.to_string().contains("unknown list_status"));

--- a/src/pipeline/outbox.rs
+++ b/src/pipeline/outbox.rs
@@ -182,13 +182,12 @@ impl OutboxPipeline {
                 sidecar.outbound = Some(outbound);
                 continue;
             }
-            if let Some(next) = &outbound.next_attempt_at {
-                if let Ok(next_time) = OffsetDateTime::parse(next, &Rfc3339) {
-                    if next_time > OffsetDateTime::now_utc() {
-                        sidecar.outbound = Some(outbound);
-                        continue;
-                    }
-                }
+            if let Some(next) = &outbound.next_attempt_at
+                && let Ok(next_time) = OffsetDateTime::parse(next, &Rfc3339)
+                && next_time > OffsetDateTime::now_utc()
+            {
+                sidecar.outbound = Some(outbound);
+                continue;
             }
             let message_path = outbox_dir.join(&sidecar.filename);
             if !message_path.exists() {

--- a/src/pipeline/reconcile.rs
+++ b/src/pipeline/reconcile.rs
@@ -52,17 +52,15 @@ pub fn prune_list(
 ) -> Result<RetentionSummary> {
     let list_dir = layout.root().join(list);
     let mut summary = RetentionSummary::default();
-    if should_prune(policy)? {
-        if list_dir.exists() {
-            for entry in fs::read_dir(&list_dir)? {
-                let entry = entry?;
-                if entry.file_type()?.is_dir() {
-                    if entry.file_name() == "attachments" {
-                        continue;
-                    }
-                    let mut removed = prune_directory(&entry.path(), policy, now)?;
-                    summary.messages_removed.append(&mut removed);
+    if should_prune(policy)? && list_dir.exists() {
+        for entry in fs::read_dir(&list_dir)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                if entry.file_name() == "attachments" {
+                    continue;
                 }
+                let mut removed = prune_directory(&entry.path(), policy, now)?;
+                summary.messages_removed.append(&mut removed);
             }
         }
     }

--- a/src/ruleset/eval.rs
+++ b/src/ruleset/eval.rs
@@ -28,7 +28,7 @@ mod tests {
     #[test]
     fn precedence_applies() {
         let addr = Address::parse("foo@bar.com", false).unwrap();
-        let banned = RuleSet::from_str("@bar.com").unwrap();
+        let banned = RuleSet::parse("@bar.com").unwrap();
         let spam = RuleSet::default();
         let accepted = RuleSet::default();
         assert_eq!(evaluate(&addr, &accepted, &spam, &banned), Route::Banned);
@@ -39,7 +39,7 @@ mod tests {
         let addr = Address::parse("foo@example.com", false).unwrap();
         let banned = RuleSet::default();
         let spam = RuleSet::default();
-        let accepted = RuleSet::from_str("@example.com").unwrap();
+        let accepted = RuleSet::parse("@example.com").unwrap();
         assert_eq!(evaluate(&addr, &accepted, &spam, &banned), Route::Accepted);
     }
 
@@ -47,7 +47,7 @@ mod tests {
     fn spam_route() {
         let addr = Address::parse("foo@spam.org", false).unwrap();
         let banned = RuleSet::default();
-        let spam = RuleSet::from_str("@spam.org").unwrap();
+        let spam = RuleSet::parse("@spam.org").unwrap();
         let accepted = RuleSet::default();
         assert_eq!(evaluate(&addr, &accepted, &spam, &banned), Route::Spam);
     }
@@ -69,9 +69,9 @@ mod tests {
         fn banned_always_wins(local in "[a-z]{1,8}", domain in "[a-z]{1,10}\\.test") {
             let raw = format!("{}@{}", local, domain);
             let addr = Address::parse(&raw, false).unwrap();
-            let accepted = RuleSet::from_str(&format!("@{}", domain)).unwrap();
-            let spam = RuleSet::from_str(&format!("{}@{}", local, domain)).unwrap();
-            let banned = RuleSet::from_str(&format!("@{}", domain)).unwrap();
+            let accepted = RuleSet::parse(&format!("@{}", domain)).unwrap();
+            let spam = RuleSet::parse(&format!("{}@{}", local, domain)).unwrap();
+            let banned = RuleSet::parse(&format!("@{}", domain)).unwrap();
             prop_assert_eq!(evaluate(&addr, &accepted, &spam, &banned), Route::Banned);
         }
 
@@ -79,8 +79,8 @@ mod tests {
         fn spam_beats_accepted(local in "[a-z]{1,8}", domain in "[a-z]{1,10}\\.example") {
             let raw = format!("{}@{}", local, domain);
             let addr = Address::parse(&raw, false).unwrap();
-            let accepted = RuleSet::from_str(&format!("@{}", domain)).unwrap();
-            let spam = RuleSet::from_str(&format!("{}@{}", local, domain)).unwrap();
+            let accepted = RuleSet::parse(&format!("@{}", domain)).unwrap();
+            let spam = RuleSet::parse(&format!("{}@{}", local, domain)).unwrap();
             let banned = RuleSet::default();
             prop_assert_eq!(evaluate(&addr, &accepted, &spam, &banned), Route::Spam);
         }

--- a/src/ruleset/loader.rs
+++ b/src/ruleset/loader.rs
@@ -34,7 +34,7 @@ impl RulesetLoader {
         let path = dir.join(".rules");
         if path.exists() {
             let data = fs::read_to_string(path)?;
-            RuleSet::from_str(&data)
+            RuleSet::parse(&data)
         } else {
             Ok(RuleSet::default())
         }
@@ -52,13 +52,15 @@ impl RulesetLoader {
 }
 
 fn default_settings_for(list: &str) -> ListSettings {
-    let mut settings = ListSettings::default();
-    settings.list_status = match list {
+    let list_status = match list {
         "spam" => "rejected".into(),
         "banned" => "banned".into(),
         _ => "accepted".into(),
     };
-    settings
+    ListSettings {
+        list_status,
+        ..ListSettings::default()
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/util/dkim.rs
+++ b/src/util/dkim.rs
@@ -47,9 +47,7 @@ pub fn ensure_ed25519_keypair(dir: &Path, selector: &str) -> Result<DkimMaterial
         .to_string();
     let dns_value = format!("v=DKIM1; k=ed25519; p={public_key}");
 
-    if generated {
-        write_atomic(&dns, dns_value.as_bytes())?;
-    } else if !dns.exists() {
+    if generated || !dns.exists() {
         write_atomic(&dns, dns_value.as_bytes())?;
     } else {
         let existing = fs::read_to_string(&dns)
@@ -65,7 +63,7 @@ pub fn ensure_ed25519_keypair(dir: &Path, selector: &str) -> Result<DkimMaterial
         private_key_path: private,
         public_key_path: public,
         dns_record_path: dns,
-        public_key: public_key,
+        public_key,
         selector: selector.to_string(),
     })
 }

--- a/src/util/logging.rs
+++ b/src/util/logging.rs
@@ -186,7 +186,7 @@ impl LogEntry {
     }
 }
 
-pub fn tail<'a>(entries: &'a [LogEntry], max: usize) -> &'a [LogEntry] {
+pub fn tail(entries: &[LogEntry], max: usize) -> &[LogEntry] {
     if entries.len() <= max {
         entries
     } else {

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -20,7 +20,7 @@ pub fn parse_delete_after(value: &str) -> Option<Duration> {
 }
 
 pub fn retention_due(last_activity: OffsetDateTime, policy: &str, now: OffsetDateTime) -> bool {
-    parse_delete_after(policy).map_or(false, |duration| last_activity + duration < now)
+    parse_delete_after(policy).is_some_and(|duration| last_activity + duration < now)
 }
 
 pub fn parse_interval(value: &str) -> Option<Duration> {

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,0 +1,7 @@
+mod dkim_signing;
+mod import_export;
+mod inbox_flow;
+mod main_smoke;
+mod outbox_retry;
+mod retention;
+mod routing;

--- a/tests/integration/routing.rs
+++ b/tests/integration/routing.rs
@@ -9,7 +9,7 @@ use owl::{
 fn routing_precedence() {
     let sender = Address::parse("eve@malicious.example", false).unwrap();
     let mut loaded = LoadedRules::default();
-    loaded.banned.rules = RuleSet::from_str("@malicious.example").unwrap();
+    loaded.banned.rules = RuleSet::parse("@malicious.example").unwrap();
     let route = determine_route(&sender, &loaded, &EnvConfig::default()).unwrap();
     assert_eq!(route, Route::Banned);
 }
@@ -18,7 +18,7 @@ fn routing_precedence() {
 fn list_settings_change_route() {
     let sender = Address::parse("ally@example.org", false).unwrap();
     let mut loaded = LoadedRules::default();
-    loaded.spam.rules = RuleSet::from_str("@example.org").unwrap();
+    loaded.spam.rules = RuleSet::parse("@example.org").unwrap();
     loaded.spam.settings.list_status = "accepted".into();
     let route = determine_route(&sender, &loaded, &EnvConfig::default()).unwrap();
     assert_eq!(route, Route::Accepted);


### PR DESCRIPTION
## Summary
- implement `FromStr` for configuration and rule parsing and update callers to use the shared helpers
- address clippy feedback across the CLI, daemon, pipelines, and utilities by simplifying conditionals and struct construction
- modernize DKIM and time helpers and update integration tests to match the new parsing APIs

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d78fdac75c83209afbf8337a30e207